### PR TITLE
Force arrange by index before time_collapse()

### DIFF
--- a/R/time_collapse.R
+++ b/R/time_collapse.R
@@ -86,6 +86,9 @@ time_collapse.tbl_time <- function(.data, period = "yearly", start_date = NULL,
 
   .data %>%
 
+    # Ensure data is arranged by index
+    arrange(!!index_sym) %>%
+
     # Add time groups
     mutate(.time_group = time_group(!! index_sym,
                                     period = period,


### PR DESCRIPTION
This is a very simple fix that will ensure that users always get consistent results from time_collapse()

Closes #19 Issue with time_summarize
