### PR TITLE
Feature faster time group

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: tibbletime
 Type: Package
 Title: Time Aware Tibbles
-Version: 0.0.2.9000
-Date: 2017-10-11
+Version: 0.0.2.9001
+Date: 2017-10-18
 Authors@R: c(
     person("Davis", "Vaughan", email = "dvaughan@business-science.io", role = c("aut", "cre")),
     person("Matt", "Dancho", email = "mdancho@business-science.io", role = c("aut"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,9 @@
-## tibbletime 0.0.2.9000
+## tibbletime 0.0.2.9001
+
+* General
+
+    * Even faster `time_group()`. This speeds up all time functions, especially
+    on large datasets.
 
 * Bug Fixes
 

--- a/R/tidyr-nest.R
+++ b/R/tidyr-nest.R
@@ -7,10 +7,7 @@ nest.tbl_time <- function(data, ..., .key = "data")  {
 
   # Attributes to keep on the list-column
   # Classes are kept on nest
-  time_attrs <- list(
-    index     = attr(data, "index"),
-    time_zone = attr(data, "time_zone")
-  )
+  time_attrs <- extract_time_attrs(data)
 
   # silent_retime because normally the outer tibble won't have dates anymore
   tidyverse_execute(data, nest, ..., .key = !! .key, silent_retime = TRUE) %>%

--- a/R/time_group.R
+++ b/R/time_group.R
@@ -117,19 +117,30 @@ time_group <- function(index, period = "yearly", start_date = NULL, ...) {
                                   tz = tz, force_class = class(index)[1],
                                   as_date_vector = TRUE)
 
+  # Numeric?
+  index <- as.numeric(index)
+  endpoint_dates <- as.numeric(endpoint_dates)
+
   # Set initial names. NA for index, groups for endpoints
   # These become groups
-  names(index) <- NA_character_
+  #names(index) <- NA_character_
   names(endpoint_dates) <- seq_len(length(endpoint_dates))
 
   # Combine the two and sort
   # All the while keeping the groups as the names in the correct position
   combined_dates <- c(endpoint_dates, index)
 
-  combined_dates_sorted <- sort(combined_dates)
+  #combined_dates_sorted <- sort(combined_dates)
+  sorted_order <- order(combined_dates)
 
   # Remove the names and convert to numeric
-  full_time_group <- as.numeric(names(combined_dates_sorted))
+  # Sorting the names only is much faster than sorting dates
+  #full_time_group <- as.numeric(names(combined_dates_sorted))
+  full_time_group <- as.numeric(names(combined_dates))[sorted_order]
+
+  # Remember location of endpoint_dates for removal later
+  endpoint_locations <- match(as.numeric(names(endpoint_dates)),
+                              full_time_group)
 
   # 'fill' the NA values forward with the correct group
   not_na <- !is.na(full_time_group)
@@ -137,7 +148,8 @@ time_group <- function(index, period = "yearly", start_date = NULL, ...) {
 
   # Pull the endpoint_dates back out so we don't have duplicates
   # Match only finds the first match so this works correctly
-  .time_group <- full_time_group[-match(endpoint_dates, combined_dates_sorted)]
+  #.time_group <- full_time_group[-match(endpoint_dates, combined_dates_sorted)]
+  .time_group <- full_time_group[-endpoint_locations]
 
   # Subtract off min-1 (takes care of starting the groups too early)
   .time_group <- .time_group - (min(.time_group) - 1)

--- a/man/time_filter.Rd
+++ b/man/time_filter.Rd
@@ -81,5 +81,10 @@ FANG[~2014]
 # Using `[` and column selection
 FANG[2013~2016, c("date", "adjusted")]
 
+# You can filter with variables
+lhs_date <- "2013"
+rhs_date <- as.Date("2014-01-01")
+time_filter(FANG, lhs_date ~ rhs_date)
+
 
 }


### PR DESCRIPTION
Improve time_group by using order() and no names. Less conversion is needed this way. Saves ~1.5 seconds on 30 million dates.