### PR TITLE
Add align parameter to rollify

### DIFF
--- a/R/rollify.R
+++ b/R/rollify.R
@@ -11,9 +11,8 @@
 #' a list-column of the rolling results.
 #' @param na_value A default value for the `NA` values at the beginning of the
 #' roll.
-#' @param align One of `"right"`, `"center"`, or `"left"` or (`"r"`, `"c"` or
-#'   `"l"`), specifying whether the index of the result should be right-,
-#'   center-, or left-aligned.
+#' @param align One of `"right"`, `"center"`, or `"left"`, specifying whether
+#' the index of the result should be right-, center-, or left-aligned.
 #'
 #' @details
 #'
@@ -139,10 +138,13 @@
 #'
 #' @export
 #'
-rollify <- function(.f, window = 1, unlist = TRUE, na_value = NULL, align = "right") {
+rollify <- function(.f, window = 1, unlist = TRUE, na_value = NULL,
+                    align = c("right", "center", "left")) {
 
   # Mappify the function
   .f <- purrr::as_mapper(.f)
+
+  align <- match.arg(align)
 
   # Return function that calls roller
   function(...) {
@@ -153,7 +155,8 @@ rollify <- function(.f, window = 1, unlist = TRUE, na_value = NULL, align = "rig
 
 # Utils ------------------------------------------------------------------------
 
-roller <- function(..., .f, window, unlist = TRUE, na_value = NULL, align = "right") {
+roller <- function(..., .f, window, unlist = TRUE, na_value = NULL,
+                   align = c("right", "center", "left")) {
 
   # na_value as NA if not specified
   if(is.null(na_value)) {
@@ -175,16 +178,16 @@ roller <- function(..., .f, window, unlist = TRUE, na_value = NULL, align = "rig
 
   # Window adjustment for align location
   window_adjust <- switch(
-    substr(tolower(align), 1, 1),
-    'l' = -window + 1,
-    'c' = -floor((window)/2),
-    0
+    match.arg(align),
+    "left"   = window - 1,
+    "center" = floor((window)/2),
+    "right"  = 0
   )
 
   # Roll and fill
   for(i in window:roll_length) {
-    .f_dots   <- lapply(.dots, function(x) {x[(i-window+1):i]})
-    filled[[i + window_adjust]] <- do.call(.f, .f_dots)
+    .f_dots <- lapply(.dots, function(x) {x[(i-window+1):i]})
+    filled[[i - window_adjust]] <- do.call(.f, .f_dots)
   }
 
   # Don't unlist if requested (when >1 value returned)

--- a/man/rollify.Rd
+++ b/man/rollify.Rd
@@ -4,7 +4,8 @@
 \alias{rollify}
 \title{Create a rolling version of any function}
 \usage{
-rollify(.f, window = 1, unlist = TRUE, na_value = NULL, align = "right")
+rollify(.f, window = 1, unlist = TRUE, na_value = NULL,
+  align = c("right", "center", "left"))
 }
 \arguments{
 \item{.f}{A function, formula, or atomic vector.
@@ -38,9 +39,8 @@ a list-column of the rolling results.}
 \item{na_value}{A default value for the \code{NA} values at the beginning of the
 roll.}
 
-\item{align}{One of \code{"right"}, \code{"center"}, or \code{"left"} or (\code{"r"}, \code{"c"} or
-\code{"l"}), specifying whether the index of the result should be right-,
-center-, or left-aligned.}
+\item{align}{One of \code{"right"}, \code{"center"}, or \code{"left"}, specifying whether
+the index of the result should be right-, center-, or left-aligned.}
 }
 \description{
 \code{rollify} returns a rolling version of the input function, with a

--- a/man/rollify.Rd
+++ b/man/rollify.Rd
@@ -4,7 +4,7 @@
 \alias{rollify}
 \title{Create a rolling version of any function}
 \usage{
-rollify(.f, window = 1, unlist = TRUE, na_value = NULL)
+rollify(.f, window = 1, unlist = TRUE, na_value = NULL, align = "right")
 }
 \arguments{
 \item{.f}{A function, formula, or atomic vector.
@@ -37,6 +37,10 @@ a list-column of the rolling results.}
 
 \item{na_value}{A default value for the \code{NA} values at the beginning of the
 roll.}
+
+\item{align}{One of \code{"right"}, \code{"center"}, or \code{"left"} or (\code{"r"}, \code{"c"} or
+\code{"l"}), specifying whether the index of the result should be right-,
+center-, or left-aligned.}
 }
 \description{
 \code{rollify} returns a rolling version of the input function, with a

--- a/tests/testthat/test_rollify.R
+++ b/tests/testthat/test_rollify.R
@@ -29,6 +29,18 @@ test_that("rollify() with function call works", {
                dplyr::mutate(test_tbl_time, test = c(NA, 1.5, 2.5)))
 })
 
+test_that("rollify() with align='left' works", {
+  test_roll_left <- rollify(mean, window = 2, align = "left")
+  expect_equal(dplyr::mutate(test_tbl_time, test = test_roll_left(value)),
+               dplyr::mutate(test_tbl_time, test = c(1.5, 2.5, NA)))
+})
+
+test_that("rollify() with align='center' works", {
+  test_roll_center <- rollify(mean, window = 3, align = "center")
+  expect_equal(dplyr::mutate(test_tbl_time, test = test_roll_center(value)),
+               dplyr::mutate(test_tbl_time, test = c(NA, 2, NA)))
+})
+
 test_that("rollify() with ~ specification works", {
   test_roll <- rollify(~mean(.x), window = 2)
   expect_equal(dplyr::mutate(test_tbl_time, test = test_roll(value)),
@@ -61,3 +73,24 @@ test_that("rollify() with unlist = FALSE works", {
   expect_equal(length(test_rolled$test[[2]]), 2L)
 })
 
+test_that("rollify() with unlist = FALSE works, align = 'left'", {
+  test_roll <- rollify(~c(mean(.x), sd(.x)), window = 2, unlist = FALSE, align = "left")
+  test_rolled <- dplyr::mutate(test_tbl_time, test = test_roll(value))
+  expect_is(test_rolled$test[[1]], "numeric")
+  expect_is(test_rolled$test[[2]], "numeric")
+  expect_is(test_rolled$test[[3]], "logical")
+  expect_equal(length(test_rolled$test[[1]]), 2L)
+})
+
+test_that("rollify() with unlist = FALSE works, align = 'center'", {
+  test_roll <- rollify(~c(mean(.x), sd(.x)), window = 3, unlist = FALSE, align = "center")
+  test_rolled <- dplyr::mutate(test_tbl_time, test = test_roll(value))
+  expect_is(test_rolled$test[[1]], "logical")
+  expect_is(test_rolled$test[[2]], "numeric")
+  expect_is(test_rolled$test[[3]], "logical")
+  expect_equal(length(test_rolled$test[[2]]), 2L)
+})
+
+test_that("rollify() throws error with incorrect align option", {
+  expect_error(rollify(mean, window = 2, align = "middle"))
+})


### PR DESCRIPTION
I really like the `rollify` function, but I needed to adjust the alignment (rollify is currently right-aligned) and I thought maybe it'd be easier to add as a parameter to the function rather than coupling a rollified function with`lag`.

This PR is fairly straight-forward, I added a parameter called `align` (similar to `align` in `zoo::rollapply()`) and then just adjust the location where the result is stored inside `rolled` so that the result index is left-, center-, or right-aligned (right is default and is same as current function).

Here's an example, compared to `zoo::rollmean()` for reference:

``` r
library(dplyr)
library(tibbletime)

window = 5

data_frame(i = 1:25, 
           x = runif(25, 0.75, 1.25)) %>% 
  mutate(
    mean_right = rollify(mean, window, align = 'right')(x),
    mean_rightZ = zoo::rollmean(x, window, fill = NA, align = 'right'),
    mean_center = rollify(mean, window, align = 'center')(x),
    mean_centerZ = zoo::rollmean(x, window, fill = NA, align = 'center'),
    mean_left = rollify(mean, window, align = 'left')(x),
    mean_leftZ = zoo::rollmean(x, window, fill = NA, align = 'left')
  ) %>% 
  print(n = 25)
```

```r
# A tibble: 25 x 8
       i     x mean_right mean_rightZ mean_center mean_centerZ mean_left mean_leftZ
   <int> <dbl>      <dbl>       <dbl>       <dbl>        <dbl>     <dbl>      <dbl>
 1     1 1.14      NA          NA          NA           NA         1.02       1.02 
 2     2 1.05      NA          NA          NA           NA         1.02       1.02 
 3     3 0.935     NA          NA           1.02         1.02      0.961      0.961
 4     4 0.776     NA          NA           1.02         1.02      0.962      0.962
 5     5 1.22       1.02        1.02        0.961        0.961     1.02       1.02 
 6     6 1.10       1.02        1.02        0.962        0.962     0.981      0.981
 7     7 0.766      0.961       0.961       1.02         1.02      0.933      0.933
 8     8 0.942      0.962       0.962       0.981        0.981     0.958      0.958
 9     9 1.09       1.02        1.02        0.933        0.933     1.01       1.01 
10    10 1.01       0.981       0.981       0.958        0.958     1.03       1.03 
11    11 0.858      0.933       0.933       1.01         1.01      1.04       1.04 
12    12 0.895      0.958       0.958       1.03         1.03      1.11       1.11 
13    13 1.21       1.01        1.01        1.04         1.04      1.16       1.16 
14    14 1.17       1.03        1.03        1.11         1.11      1.07       1.07 
15    15 1.05       1.04        1.04        1.16         1.16      1.00       1.00 
16    16 1.22       1.11        1.11        1.07         1.07      0.995      0.995
17    17 1.13       1.16        1.16        1.00         1.00      0.960      0.960
18    18 0.799      1.07        1.07        0.995        0.995     0.948      0.948
19    19 0.824      1.00        1.00        0.960        0.960     1.03       1.03 
20    20 1.01       0.995       0.995       0.948        0.948     1.11       1.11 
21    21 1.04       0.960       0.960       1.03         1.03      1.16       1.16 
22    22 1.07       0.948       0.948       1.11         1.11     NA         NA    
23    23 1.23       1.03        1.03        1.16         1.16     NA         NA    
24    24 1.22       1.11        1.11       NA           NA        NA         NA    
25    25 1.25       1.16        1.16       NA           NA        NA         NA    
```

I also checked that it worked as expected with models, grouped variables, etc.

```r
library(gapminder)

# Rolling regressions are easy to implement
lm_roll <- rollify(~lm(.x ~ .y), window = 5, unlist = FALSE, align = 'center')

gapminder %>%
  dplyr::group_by(country) %>%
  dplyr::mutate(rolling_lm = lm_roll(lifeExp, year))
#> # A tibble: 1,704 x 7
#> # Groups:   country [142]
#>    country     continent  year lifeExp      pop gdpPercap rolling_lm
#>    <fct>       <fct>     <int>   <dbl>    <int>     <dbl> <list>    
#>  1 Afghanistan Asia       1952    28.8  8425333       779 <lgl [1]> 
#>  2 Afghanistan Asia       1957    30.3  9240934       821 <lgl [1]>  
#>  3 Afghanistan Asia       1962    32.0 10267083       853 <S3: lm>  #<< starts at 3 instead of 5
#>  4 Afghanistan Asia       1967    34.0 11537966       836 <S3: lm>  
#>  5 Afghanistan Asia       1972    36.1 13079460       740 <S3: lm>  
#>  6 Afghanistan Asia       1977    38.4 14880372       786 <S3: lm>  
#>  7 Afghanistan Asia       1982    39.9 12881816       978 <S3: lm>  
#>  8 Afghanistan Asia       1987    40.8 13867957       852 <S3: lm>  
#>  9 Afghanistan Asia       1992    41.7 16317921       649 <S3: lm>  
#> 10 Afghanistan Asia       1997    41.8 22227415       635 <S3: lm>  
#> # ... with 1,694 more rows
```