### PR TITLE
Allow rollify() to use larger window size than length of data.

### DIFF
--- a/R/rollify.R
+++ b/R/rollify.R
@@ -167,6 +167,10 @@ roller <- function(..., .f, window, unlist = TRUE, na_value = NULL) {
   # as the length of the dataset
   roll_length <- length(.dots[[1]])
 
+  if(roll_length < window) {
+    return(rep(na_value, roll_length))
+  }
+
   # Initialize `filled` vector
   filled <- rlang::rep_along(1:roll_length, list(na_value))
 
@@ -192,12 +196,6 @@ check_dots <- function(x, window) {
   assertthat::assert_that(length(x) > 0,
                           msg = "At least 1 data argument must be supplied to be
                           passed on to the rolling function")
-
-
-  # The window must be smaller than the length of the data
-  assertthat::assert_that(window <= length(x[[1]]),
-                          msg = "Cannot roll apply with a window larger than the
-                          length of the data")
 
 
   # Length of every element of .dots should be the same

--- a/tests/testthat/test_rollify.R
+++ b/tests/testthat/test_rollify.R
@@ -61,3 +61,8 @@ test_that("rollify() with unlist = FALSE works", {
   expect_equal(length(test_rolled$test[[2]]), 2L)
 })
 
+test_that("rollify() handles windows larger than length of data", {
+  test_roll <- rollify(mean, window = 4)
+  expect_equal(dplyr::mutate(test_tbl_time, test = test_roll(value)),
+               dplyr::mutate(test_tbl_time, test = c(NA, NA, NA)))
+})


### PR DESCRIPTION
As mentioned in #65 I'd like to use rollify() for data sizes smaller than window size.