### PR TITLE
Fix tests to work with both dplyr 0.7.8 and 0.8.0

### DIFF
--- a/tests/testthat/test_as_period.R
+++ b/tests/testthat/test_as_period.R
@@ -14,7 +14,7 @@ test_tbl_time_g <- as_tbl_time(FANG, date) %>%
 
 test_that("Converting to more granular throws error", {
   expect_error(as_period(test_tbl_time, "hourly"),
-               regexp = "Only year, quarter, month, week, and day periods are allowed for an index of class Date.")
+               regexp = "Only year, quarter, month, week, and day periods are allowed for an index of class Date")
 })
 
 test_that("Can convert to monthly", {


### PR DESCRIPTION
I'm not sure why, but dplyr 0.7.8 used to add a `.` to the error message apparently, and 0.8.0 does not. This breaks this 📦 : 

```
> revdep_details(revdep = "tibbletime")
══ Reverse dependency check ════════════════════════════════════════════════════════════════ tibbletime 0.1.1 ══

Status: BROKEN

── Newly failing

✖ checking tests ...

── Before ──────────────────────────────────────────────────────────────────────────────────────────────────────
0 errors ✔ | 0 warnings ✔ | 0 notes ✔

── After ───────────────────────────────────────────────────────────────────────────────────────────────────────
❯ checking tests ...
  See below...

── Test failures ───────────────────────────────────────────────────────────────────────────────── testthat ────

> library(testthat)
> library(tibbletime)

Attaching package: 'tibbletime'

The following object is masked from 'package:stats':

    filter

> 
> test_check("tibbletime")
── 1. Failure: Converting to more granular throws error (@test_as_period.R#16)  
`as_period(test_tbl_time, "hourly")` threw an error with unexpected message.
Expected match: "Only year, quarter, month, week, and day periods are allowed for an index of class Date."
Actual message: "Only year, quarter, month, week, and day periods are allowed for an index of class Date"

══ testthat results  ═══════════════════════════════════════════════════════════
OK: 128 SKIPPED: 0 FAILED: 1
1. Failure: Converting to more granular throws error (@test_as_period.R#16) 

Error: testthat unit tests failed
Execution halted

1 error ✖ | 0 warnings ✔ | 0 notes ✔
```