### PR TITLE
Include the possibility to use an expanding rather than rolling window

### DIFF
--- a/R/rollify.R
+++ b/R/rollify.R
@@ -47,12 +47,20 @@
 #'        normal_mean  = mean(adjusted),
 #'        rolling_mean = mean_roll_5(adjusted))
 #'
+#' # Turn the normal mean function into an expanding mean starting with a 5 row window
+#' mean_roll_5e <- rollify(mean, window = 5, expand = TRUE)
+#'
+#' dplyr::mutate(FB,
+#'        normal_mean  = mean(adjusted),
+#'        rolling_mean = mean_roll_5e(adjusted))
+#'
 #' # There's nothing stopping you from combining multiple rolling functions with
 #' # different window sizes in the same mutate call
 #' mean_roll_10 <- rollify(mean, window = 10)
 #'
 #' dplyr::mutate(FB,
 #'        rolling_mean_5  = mean_roll_5(adjusted),
+#'        rolling_mean_5e  = mean_roll_5e(adjusted),
 #'        rolling_mean_10 = mean_roll_10(adjusted))
 #'
 #' # Functions with multiple args and optional args ----------------------------
@@ -144,14 +152,14 @@ rollify <- function(.f, window = 1, unlist = TRUE, na_value = NULL, expand = FAL
 
   # Return function that calls roller
   function(...) {
-    roller(..., .f = .f, window = window, unlist = unlist, na_value = na_value)
+    roller(..., .f = .f, window = window, unlist = unlist, na_value = na_value, expand = expand)
   }
 }
 
 
 # Utils ------------------------------------------------------------------------
 
-roller <- function(..., .f, window, unlist = TRUE, na_value = NULL) {
+roller <- function(..., .f, window, unlist = TRUE, na_value = NULL, expand = FALSE) {
 
   # na_value as NA if not specified
   if(is.null(na_value)) {

--- a/R/rollify.R
+++ b/R/rollify.R
@@ -11,6 +11,7 @@
 #' a list-column of the rolling results.
 #' @param na_value A default value for the `NA` values at the beginning of the
 #' roll.
+#' @param expand Calculate for rolling 8default) or expanding window.
 #'
 #' @details
 #'
@@ -136,7 +137,7 @@
 #'
 #' @export
 #'
-rollify <- function(.f, window = 1, unlist = TRUE, na_value = NULL) {
+rollify <- function(.f, window = 1, unlist = TRUE, na_value = NULL, expand = FALSE) {
 
   # Mappify the function
   .f <- purrr::as_mapper(.f)
@@ -171,9 +172,16 @@ roller <- function(..., .f, window, unlist = TRUE, na_value = NULL) {
   filled <- rlang::rep_along(1:roll_length, list(na_value))
 
   # Roll and fill
-  for(i in window:roll_length) {
-    .f_dots   <- lapply(.dots, function(x) {x[(i-window+1):i]})
-    filled[[i]] <- do.call(.f, .f_dots)
+  if (expand) {
+    for(i in window:roll_length) {
+      .f_dots   <- lapply(.dots, function(x) {x[1:i]})
+      filled[[i]] <- do.call(.f, .f_dots)
+    }
+  } else {
+    for(i in window:roll_length) {
+      .f_dots   <- lapply(.dots, function(x) {x[(i-window+1):i]})
+      filled[[i]] <- do.call(.f, .f_dots)
+    }
   }
 
   # Don't unlist if requested (when >1 value returned)


### PR DESCRIPTION
In the past I have been heavily relying on the rollify function, e.g. to create rolling betas or rolling standard deviations for my asset pricing studies. However, there exist many applications in finance (e.g. forecasting regressions) that are usually based on an expanding window rather than a rolling one. So I have just included an option expand (standard: FALSE) to use one or the other. there might be a faster version of doing it (e.g. not using an if/else statement but just using (EXPAND*1+(1-EXPAND)*(i-window+1)) but it currently works well for me. Examples are included in the file.