### PR TITLE
Change argument name from "start_date" to "start_date_for_collapse"

### DIFF
--- a/R/collapse_index.R
+++ b/R/collapse_index.R
@@ -73,7 +73,7 @@
 #' @export
 #'
 collapse_index <- function(index, period = "yearly",
-                           start_date = NULL, side = "end", clean = FALSE, ...) {
+                           start_date_for_collapse = NULL, side = "end", clean = FALSE, ...) {
 
   # Side either start or end
   assert_valid_side(side)
@@ -86,7 +86,7 @@ collapse_index <- function(index, period = "yearly",
   if(clean) {
 
     # Create datetime endpoints
-    endpoints <- make_endpoints(index, period, start_date)
+    endpoints <- make_endpoints(index, period, start_date_for_collapse)
 
     # Create a numeric index containing the endpoints positioned in a way
     # to replace the old index
@@ -103,7 +103,7 @@ collapse_index <- function(index, period = "yearly",
   } else {
 
     # Partition index
-    index_part <- partition_index(index, period, start_date)
+    index_part <- partition_index(index, period, start_date_for_collapse)
 
     if(side == "start") {
       # For each partition, find the first date position
@@ -182,7 +182,7 @@ collapse_index <- function(index, period = "yearly",
 #'   dplyr::summarise_all(sd)
 #'
 #' @export
-collapse_by <- function(.tbl_time, period = "yearly", start_date = NULL, side = "end", clean = FALSE, ...) {
+collapse_by <- function(.tbl_time, period = "yearly", start_date_for_collapse = NULL, side = "end", clean = FALSE, ...) {
 
   index_quo  <- get_index_quo(.tbl_time)
   index_char <- get_index_char(.tbl_time)
@@ -192,7 +192,7 @@ collapse_by <- function(.tbl_time, period = "yearly", start_date = NULL, side = 
     !! index_char := collapse_index(
       index      = !! index_quo,
       period     = period,
-      start_date = start_date,
+      start_date_for_collapse = start_date_for_collapse,
       side       = side,
       clean      = clean,
       ...

--- a/man/collapse_by.Rd
+++ b/man/collapse_by.Rd
@@ -4,8 +4,8 @@
 \alias{collapse_by}
 \title{Collapse a tbl_time object by its index}
 \usage{
-collapse_by(.tbl_time, period = "yearly", start_date = NULL,
-  side = "end", clean = FALSE, ...)
+collapse_by(.tbl_time, period = "yearly",
+  start_date_for_collapse = NULL, side = "end", clean = FALSE, ...)
 }
 \arguments{
 \item{.tbl_time}{A \code{tbl_time} object.}
@@ -25,11 +25,6 @@ second, millisecond and microsecond periodicities.
 
 Additionally, you have the option of passing in a vector of dates to
 use as custom and more flexible boundaries.}
-
-\item{start_date}{Optional argument used to
-specify the start date for the
-first group. The default is to start at the closest period boundary
-below the minimum date in the supplied index.}
 
 \item{side}{Whether to return the date at the beginning or the end of
 the new period. By default, the "end" of the period.

--- a/man/collapse_index.Rd
+++ b/man/collapse_index.Rd
@@ -5,8 +5,8 @@
 \title{Collapse an index vector so that all observations in an interval share the
 same date}
 \usage{
-collapse_index(index, period = "yearly", start_date = NULL,
-  side = "end", clean = FALSE, ...)
+collapse_index(index, period = "yearly",
+  start_date_for_collapse = NULL, side = "end", clean = FALSE, ...)
 }
 \arguments{
 \item{index}{An index vector.}
@@ -26,11 +26,6 @@ second, millisecond and microsecond periodicities.
 
 Additionally, you have the option of passing in a vector of dates to
 use as custom and more flexible boundaries.}
-
-\item{start_date}{Optional argument used to
-specify the start date for the
-first group. The default is to start at the closest period boundary
-below the minimum date in the supplied index.}
 
 \item{side}{Whether to return the date at the beginning or the end of
 the new period. By default, the "end" of the period.


### PR DESCRIPTION
This change should make it less likely for problems to occur if a user is working with a dataframe that has a column named "**start_date**". 

This came up on this [Stack Overflow question](https://stackoverflow.com/questions/57800977/error-when-using-anomalizetime-decompose-length-of-assertion-is-not-1).   

This PR is intended is intended to close [Issue 81](https://github.com/business-science/tibbletime/issues/81). 

I ran R CMD check to ensure that the package still works after making the change. The check passes with 0 errors, 1 warning, 0 notes. The warning says that the change to the argument name hasn't been documented. I'm not yet quite sure how to do that properly. 

