### PR TITLE
Updates for lubridate/timechange

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,5 +43,5 @@ Suggests:
     testthat,
     tidyr (>= 1.0.0)
 VignetteBuilder: knitr
-LinkingTo: Rcpp (>= 1.0.9)
+LinkingTo: Rcpp (>= 1.0.10)
 LazyData: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Imports:
     dplyr (>= 1.0.10),
     glue (>= 1.6.2),
     hms (>= 1.1.2),
-    lubridate (>= 1.8.0),
+    lubridate (>= 1.9.1),
     pillar (>= 1.8.1),
     purrr (>= 0.3.5),
     Rcpp (>= 1.0.9),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tibbletime (development version)
 
+* Adapted to stricter parsing in lubridate and timechange (#103).
+
 # tibbletime 0.1.7
 
 * Fixed usage of `|` rather than `||` in the C++ code to satisfy a CRAN warning.

--- a/R/as_period.R
+++ b/R/as_period.R
@@ -34,26 +34,23 @@
 #' FB <- as_tbl_time(FB, date)
 #'
 #' # Aggregate FB to yearly data
-#' as_period(FB, "yearly")
+#' as_period(FB, "year")
 #'
 #' # Aggregate FB to every 2 years
 #' as_period(FB, "2 years")
 #'
 #' # Aggregate FB to yearly data, but use the last data point available
 #' # in that period
-#' as_period(FB, "yearly", side = "end")
+#' as_period(FB, "year", side = "end")
 #'
 #' # Aggregate FB to yearly data, end of period, and include the first
 #' # endpoint
-#' as_period(FB, "yearly", side = "end", include_endpoints = TRUE)
+#' as_period(FB, "year", side = "end", include_endpoints = TRUE)
 #'
 #' # Aggregate to weekly. Notice that it only uses the earliest day available
 #' # in the data set at that periodicity. It will not set the date of the first
 #' # row to 2013-01-01 because that date did not exist in the original data set.
 #' as_period(FB, "weekly")
-#'
-#' # Aggregate to every other week
-#' as_period(FB, "2 weeks")
 #'
 #' # FB is daily data, aggregate to minute?
 #' # Not allowed for Date class indices, an error is thrown
@@ -68,7 +65,7 @@
 #' FANG <- dplyr::group_by(FANG, symbol)
 #'
 #' # Respects groups
-#' as_period(FANG, "yearly")
+#' as_period(FANG, "year")
 #'
 #' # Every 6 months, respecting groups
 #' as_period(FANG, "6 months")
@@ -121,21 +118,21 @@
 #'
 #' @export
 #'
-as_period <- function(.tbl_time, period = "yearly",
+as_period <- function(.tbl_time, period = "year",
                       start_date = NULL, side = "start",
                       include_endpoints = FALSE, ...) {
   UseMethod("as_period")
 }
 
 #' @export
-as_period.default <- function(.tbl_time, period = "yearly",
+as_period.default <- function(.tbl_time, period = "year",
                               start_date = NULL, side = "start",
                               include_endpoints = FALSE, ...) {
   stop("Object is not of class `tbl_time`.", call. = FALSE)
 }
 
 #' @export
-as_period.tbl_time <- function(.tbl_time, period = "yearly",
+as_period.tbl_time <- function(.tbl_time, period = "year",
                                start_date = NULL, side = "start",
                                include_endpoints = FALSE, ...) {
 

--- a/R/collapse_index.R
+++ b/R/collapse_index.R
@@ -43,7 +43,7 @@
 #' # A common workflow is to group on the new date column
 #' # to perform a time based summary
 #' FB %>%
-#'   dplyr::mutate(date = collapse_index(date, "yearly")) %>%
+#'   dplyr::mutate(date = collapse_index(date, "year")) %>%
 #'   dplyr::group_by(date) %>%
 #'   dplyr::summarise_if(is.numeric, mean)
 #'
@@ -65,14 +65,14 @@
 #' # Collapse each group to monthly,
 #' # calculate monthly standard deviation for each column
 #' FANG %>%
-#'   dplyr::mutate(date = collapse_index(date, "monthly")) %>%
+#'   dplyr::mutate(date = collapse_index(date, "month")) %>%
 #'   dplyr::group_by(symbol, date) %>%
 #'   dplyr::summarise_all(sd)
 #'
 #'
 #' @export
 #'
-collapse_index <- function(index, period = "yearly",
+collapse_index <- function(index, period = "year",
                            start_date = NULL, side = "end", clean = FALSE, ...) {
 
   # Side either start or end
@@ -163,7 +163,7 @@ collapse_index <- function(index, period = "yearly",
 #' # A common workflow is to group on the collapsed date column
 #' # to perform a time based summary
 #' FB %>%
-#'   collapse_by("yearly") %>%
+#'   collapse_by("year") %>%
 #'   dplyr::group_by(date) %>%
 #'   dplyr::summarise_if(is.numeric, mean)
 #'
@@ -177,12 +177,12 @@ collapse_index <- function(index, period = "yearly",
 #' # Collapse each group to monthly,
 #' # calculate monthly standard deviation for each column
 #' FANG %>%
-#'   collapse_by("monthly") %>%
+#'   collapse_by("month") %>%
 #'   dplyr::group_by(symbol, date) %>%
 #'   dplyr::summarise_all(sd)
 #'
 #' @export
-collapse_by <- function(.tbl_time, period = "yearly", start_date = NULL, side = "end", clean = FALSE, ...) {
+collapse_by <- function(.tbl_time, period = "year", start_date = NULL, side = "end", clean = FALSE, ...) {
 
   index_quo  <- get_index_quo(.tbl_time)
   index_char <- get_index_char(.tbl_time)

--- a/R/create_series.R
+++ b/R/create_series.R
@@ -18,7 +18,7 @@
 #' @examples
 #'
 #' # Every day in 2013
-#' create_series(~'2013', 'daily')
+#' create_series(~'2013', 'day')
 #'
 #' # Every other day in 2013
 #' create_series(~'2013', '2 d')
@@ -55,7 +55,7 @@
 #'
 #'
 #' @export
-create_series <- function(time_formula, period = "daily",
+create_series <- function(time_formula, period = "day",
                           class = "POSIXct", include_end = FALSE,
                           tz = "UTC", as_vector = FALSE) {
 

--- a/R/partition_index.R
+++ b/R/partition_index.R
@@ -12,7 +12,7 @@
 #'
 #'   Note that you can pass the specification in a flexible way:
 #'
-#'   * 1 Year: `'1 year'` / `'1 Y'` / `'1 yearly'` / `'yearly'`
+#'   * 1 Year: `'1 year'` / `'1 Y'`
 #'
 #'   This shorthand is available for year, quarter, month, day, hour, minute,
 #'   second, millisecond and microsecond periodicities.
@@ -49,7 +49,7 @@
 #' @export
 #' @rdname partition_index
 #'
-partition_index <- function(index, period = "yearly", start_date = NULL, ...) {
+partition_index <- function(index, period = "year", start_date = NULL, ...) {
 
   .index <- to_posixct_numeric(index)
 

--- a/R/time_join.R
+++ b/R/time_join.R
@@ -1,6 +1,6 @@
 # # both must be tbl_time
 #
-# time_left_join <- function(x, y, by = NULL, period = "yearly", copy = FALSE, suffix = c(".x", ".y"), ...) {
+# time_left_join <- function(x, y, by = NULL, period = "year", copy = FALSE, suffix = c(".x", ".y"), ...) {
 #
 #   if(get_index_char(x) %in% by || get_index_char(y) %in% by) {
 #     stop("Do not specify the time index in `by`. Use `period` instead.")
@@ -15,7 +15,7 @@
 #     select(-.time_group)
 # }
 #
-# time_right_join <- function(x, y, by = NULL, period = "yearly", copy = FALSE, suffix = c(".x", ".y"), ...) {
+# time_right_join <- function(x, y, by = NULL, period = "year", copy = FALSE, suffix = c(".x", ".y"), ...) {
 #
 #   x <- mutate(x, .time_group = partition_index(!! get_index_quo(x), period = period))
 #   y <- mutate(y, .time_group = partition_index(!! get_index_quo(y), period = period))

--- a/man/as_period.Rd
+++ b/man/as_period.Rd
@@ -6,7 +6,7 @@
 \usage{
 as_period(
   .tbl_time,
-  period = "yearly",
+  period = "year",
   start_date = NULL,
   side = "start",
   include_endpoints = FALSE,
@@ -23,7 +23,7 @@ a space between the two.
 
 Note that you can pass the specification in a flexible way:
 \itemize{
-\item 1 Year: \code{'1 year'} / \code{'1 Y'} / \code{'1 yearly'} / \code{'yearly'}
+\item 1 Year: \code{'1 year'} / \code{'1 Y'}
 }
 
 This shorthand is available for year, quarter, month, day, hour, minute,
@@ -71,26 +71,23 @@ data(FB)
 FB <- as_tbl_time(FB, date)
 
 # Aggregate FB to yearly data
-as_period(FB, "yearly")
+as_period(FB, "year")
 
 # Aggregate FB to every 2 years
 as_period(FB, "2 years")
 
 # Aggregate FB to yearly data, but use the last data point available
 # in that period
-as_period(FB, "yearly", side = "end")
+as_period(FB, "year", side = "end")
 
 # Aggregate FB to yearly data, end of period, and include the first
 # endpoint
-as_period(FB, "yearly", side = "end", include_endpoints = TRUE)
+as_period(FB, "year", side = "end", include_endpoints = TRUE)
 
 # Aggregate to weekly. Notice that it only uses the earliest day available
 # in the data set at that periodicity. It will not set the date of the first
 # row to 2013-01-01 because that date did not exist in the original data set.
 as_period(FB, "weekly")
-
-# Aggregate to every other week
-as_period(FB, "2 weeks")
 
 # FB is daily data, aggregate to minute?
 # Not allowed for Date class indices, an error is thrown
@@ -105,7 +102,7 @@ FANG <- as_tbl_time(FANG, date)
 FANG <- dplyr::group_by(FANG, symbol)
 
 # Respects groups
-as_period(FANG, "yearly")
+as_period(FANG, "year")
 
 # Every 6 months, respecting groups
 as_period(FANG, "6 months")

--- a/man/ceiling_index.Rd
+++ b/man/ceiling_index.Rd
@@ -9,12 +9,19 @@ ceiling_index(x, unit = "seconds")
 \arguments{
 \item{x}{a vector of date-time objects}
 
-\item{unit}{a character string specifying a time unit or a multiple of a unit
-to be rounded to. Valid base units are \code{second}, \code{minute}, \code{hour}, \code{day},
-\code{week}, \code{month}, \code{bimonth}, \code{quarter}, \code{season}, \code{halfyear} and
-\code{year}. Arbitrary unique English abbreviations as in the \code{\link[lubridate:period]{period()}}
-constructor are allowed. Rounding to multiples of units (except weeks) is
-supported.}
+\item{unit}{a string, \code{Period} object or a date-time object. When a singleton string,
+it specifies a time unit or a multiple of a unit to be rounded to. Valid base units
+are \code{second}, \code{minute}, \code{hour}, \code{day}, \code{week}, \code{month}, \code{bimonth}, \code{quarter},
+\code{season}, \code{halfyear} and \code{year}. Arbitrary unique English abbreviations as in the
+\code{\link[lubridate:period]{period()}} constructor are allowed. Rounding to multiples of units (except weeks)
+is supported. When \code{unit} is a \code{Period} object, units of the period objects are
+used. This is equivalent to converting the period object to its string
+representation and passing as \code{unit} argument.
+
+When \code{unit} is a date-time object rounding is done to the nearest of the
+elements in \code{unit}. If range of \code{unit} vector does not cover the range of
+\code{x} \code{ceiling_date()} and \code{floor_date()} round to the \code{max(x)} and \code{min(x)}
+for elements that fall outside of \code{range(unit)}.}
 }
 \description{
 This is a thin wrapper around a \code{\link[lubridate:round_date]{lubridate::ceiling_date()}} that works

--- a/man/collapse_by.Rd
+++ b/man/collapse_by.Rd
@@ -6,7 +6,7 @@
 \usage{
 collapse_by(
   .tbl_time,
-  period = "yearly",
+  period = "year",
   start_date = NULL,
   side = "end",
   clean = FALSE,
@@ -23,7 +23,7 @@ a space between the two.
 
 Note that you can pass the specification in a flexible way:
 \itemize{
-\item 1 Year: \code{'1 year'} / \code{'1 Y'} / \code{'1 yearly'} / \code{'yearly'}
+\item 1 Year: \code{'1 year'} / \code{'1 Y'}
 }
 
 This shorthand is available for year, quarter, month, day, hour, minute,
@@ -70,7 +70,7 @@ collapse_by(FB, "weekly")
 # A common workflow is to group on the collapsed date column
 # to perform a time based summary
 FB \%>\%
-  collapse_by("yearly") \%>\%
+  collapse_by("year") \%>\%
   dplyr::group_by(date) \%>\%
   dplyr::summarise_if(is.numeric, mean)
 
@@ -84,7 +84,7 @@ FANG <- FANG \%>\%
 # Collapse each group to monthly,
 # calculate monthly standard deviation for each column
 FANG \%>\%
-  collapse_by("monthly") \%>\%
+  collapse_by("month") \%>\%
   dplyr::group_by(symbol, date) \%>\%
   dplyr::summarise_all(sd)
 

--- a/man/collapse_index.Rd
+++ b/man/collapse_index.Rd
@@ -7,7 +7,7 @@ same date}
 \usage{
 collapse_index(
   index,
-  period = "yearly",
+  period = "year",
   start_date = NULL,
   side = "end",
   clean = FALSE,
@@ -24,7 +24,7 @@ a space between the two.
 
 Note that you can pass the specification in a flexible way:
 \itemize{
-\item 1 Year: \code{'1 year'} / \code{'1 Y'} / \code{'1 yearly'} / \code{'yearly'}
+\item 1 Year: \code{'1 year'} / \code{'1 Y'}
 }
 
 This shorthand is available for year, quarter, month, day, hour, minute,
@@ -80,7 +80,7 @@ dplyr::mutate(FB, date = collapse_index(date, "weekly"))
 # A common workflow is to group on the new date column
 # to perform a time based summary
 FB \%>\%
-  dplyr::mutate(date = collapse_index(date, "yearly")) \%>\%
+  dplyr::mutate(date = collapse_index(date, "year")) \%>\%
   dplyr::group_by(date) \%>\%
   dplyr::summarise_if(is.numeric, mean)
 
@@ -102,7 +102,7 @@ FANG <- FANG \%>\%
 # Collapse each group to monthly,
 # calculate monthly standard deviation for each column
 FANG \%>\%
-  dplyr::mutate(date = collapse_index(date, "monthly")) \%>\%
+  dplyr::mutate(date = collapse_index(date, "month")) \%>\%
   dplyr::group_by(symbol, date) \%>\%
   dplyr::summarise_all(sd)
 

--- a/man/create_series.Rd
+++ b/man/create_series.Rd
@@ -6,7 +6,7 @@
 \usage{
 create_series(
   time_formula,
-  period = "daily",
+  period = "day",
   class = "POSIXct",
   include_end = FALSE,
   tz = "UTC",
@@ -25,7 +25,7 @@ a space between the two.
 
 Note that you can pass the specification in a flexible way:
 \itemize{
-\item 1 Year: \code{'1 year'} / \code{'1 Y'} / \code{'1 yearly'} / \code{'yearly'}
+\item 1 Year: \code{'1 year'} / \code{'1 Y'}
 }
 
 This shorthand is available for year, quarter, month, day, hour, minute,
@@ -52,7 +52,7 @@ a \code{date} column populated with a sequence of dates.
 \examples{
 
 # Every day in 2013
-create_series(~'2013', 'daily')
+create_series(~'2013', 'day')
 
 # Every other day in 2013
 create_series(~'2013', '2 d')

--- a/man/floor_index.Rd
+++ b/man/floor_index.Rd
@@ -9,12 +9,19 @@ floor_index(x, unit = "seconds")
 \arguments{
 \item{x}{a vector of date-time objects}
 
-\item{unit}{a character string specifying a time unit or a multiple of a unit
-to be rounded to. Valid base units are \code{second}, \code{minute}, \code{hour}, \code{day},
-\code{week}, \code{month}, \code{bimonth}, \code{quarter}, \code{season}, \code{halfyear} and
-\code{year}. Arbitrary unique English abbreviations as in the \code{\link[lubridate:period]{period()}}
-constructor are allowed. Rounding to multiples of units (except weeks) is
-supported.}
+\item{unit}{a string, \code{Period} object or a date-time object. When a singleton string,
+it specifies a time unit or a multiple of a unit to be rounded to. Valid base units
+are \code{second}, \code{minute}, \code{hour}, \code{day}, \code{week}, \code{month}, \code{bimonth}, \code{quarter},
+\code{season}, \code{halfyear} and \code{year}. Arbitrary unique English abbreviations as in the
+\code{\link[lubridate:period]{period()}} constructor are allowed. Rounding to multiples of units (except weeks)
+is supported. When \code{unit} is a \code{Period} object, units of the period objects are
+used. This is equivalent to converting the period object to its string
+representation and passing as \code{unit} argument.
+
+When \code{unit} is a date-time object rounding is done to the nearest of the
+elements in \code{unit}. If range of \code{unit} vector does not cover the range of
+\code{x} \code{ceiling_date()} and \code{floor_date()} round to the \code{max(x)} and \code{min(x)}
+for elements that fall outside of \code{range(unit)}.}
 }
 \description{
 This is a thin wrapper around a \code{\link[lubridate:round_date]{lubridate::floor_date()}} that works

--- a/man/parse_period.Rd
+++ b/man/parse_period.Rd
@@ -14,7 +14,7 @@ a space between the two.
 
 Note that you can pass the specification in a flexible way:
 \itemize{
-\item 1 Year: \code{'1 year'} / \code{'1 Y'} / \code{'1 yearly'} / \code{'yearly'}
+\item 1 Year: \code{'1 year'} / \code{'1 Y'}
 }
 
 This shorthand is available for year, quarter, month, day, hour, minute,

--- a/man/partition_index.Rd
+++ b/man/partition_index.Rd
@@ -4,7 +4,7 @@
 \alias{partition_index}
 \title{Partition an index vector into an integer vector representing groups}
 \usage{
-partition_index(index, period = "yearly", start_date = NULL, ...)
+partition_index(index, period = "year", start_date = NULL, ...)
 }
 \arguments{
 \item{index}{A vector of date indices to create groups for.}
@@ -16,7 +16,7 @@ a space between the two.
 
 Note that you can pass the specification in a flexible way:
 \itemize{
-\item 1 Year: \code{'1 year'} / \code{'1 Y'} / \code{'1 yearly'} / \code{'yearly'}
+\item 1 Year: \code{'1 year'} / \code{'1 Y'}
 }
 
 This shorthand is available for year, quarter, month, day, hour, minute,

--- a/man/rollify.Rd
+++ b/man/rollify.Rd
@@ -7,25 +7,13 @@
 rollify(.f, window = 1, unlist = TRUE, na_value = NULL)
 }
 \arguments{
-\item{.f}{A function, formula, or vector (not necessarily atomic).
-
-If a \strong{function}, it is used as is.
-
-If a \strong{formula}, e.g. \code{~ .x + 2}, it is converted to a function. There
-are three ways to refer to the arguments:
+\item{.f}{A function to modify, specified in one of the following ways:
 \itemize{
-\item For a single argument function, use \code{.}
-\item For a two argument function, use \code{.x} and \code{.y}
-\item For more arguments, use \code{..1}, \code{..2}, \code{..3} etc
-}
-
-This syntax allows you to create very compact anonymous functions.
-
-If \strong{character vector}, \strong{numeric vector}, or \strong{list}, it is
-converted to an extractor function. Character vectors index by
-name and numeric vectors index by position; use a list to index
-by position and name at different levels. If a component is not
-present, the value of \code{.default} will be returned.}
+\item A named function, e.g. \code{mean}.
+\item An anonymous function, e.g. \verb{\\(x) x + 1} or \code{function(x) x + 1}.
+\item A formula, e.g. \code{~ .x + 1}. Only recommended if you require backward
+compatibility with older versions of R.
+}}
 
 \item{window}{The window size to roll over}
 
@@ -165,5 +153,5 @@ FANG \%>\%
 
 }
 \seealso{
-\link[purrr:safely]{purrr::safely}, \link[purrr:safely]{purrr::possibly}
+\link[purrr:safely]{purrr::safely}, \link[purrr:possibly]{purrr::possibly}
 }

--- a/tests/testthat/test_as_period.R
+++ b/tests/testthat/test_as_period.R
@@ -13,39 +13,39 @@ test_tbl_time_g <- as_tbl_time(FANG, date) %>%
 # Tests
 
 test_that("Converting to more granular throws error", {
-  expect_error(as_period(test_tbl_time, "hourly"))
+  expect_error(as_period(test_tbl_time, "hour"))
 })
 
 test_that("Can convert to monthly", {
-  test_period <- as_period(test_tbl_time, "monthly")
+  test_period <- as_period(test_tbl_time, "month")
   expect_equal(nrow(test_period), 48L)
   expect_equal(ncol(test_period), 8L)
   expect_equal(test_period$date[2], as.Date("2013-02-01"))
 })
 
 test_that("Can convert to monthly - end", {
-  test_period <- as_period(test_tbl_time, "monthly", side = "end")
+  test_period <- as_period(test_tbl_time, "month", side = "end")
   expect_equal(nrow(test_period), 48L)
   expect_equal(ncol(test_period), 8L)
   expect_equal(test_period$date[2], as.Date("2013-02-28"))
 })
 
 test_that("Can convert to yearly", {
-  test_period <- as_period(test_tbl_time, "yearly")
+  test_period <- as_period(test_tbl_time, "year")
   expect_equal(nrow(test_period), 4L)
   expect_equal(ncol(test_period), 8L)
   expect_equal(test_period$date[2], as.Date("2014-01-02"))
 })
 
 test_that("Can convert to yearly - end", {
-  test_period <- as_period(test_tbl_time, "yearly", side = "end")
+  test_period <- as_period(test_tbl_time, "year", side = "end")
   expect_equal(nrow(test_period), 4L)
   expect_equal(ncol(test_period), 8L)
   expect_equal(test_period$date[2], as.Date("2014-12-31"))
 })
 
 test_that("Include endpoints with side = 'start' includes last point", {
-  start <- as_period(test_tbl_time, "yearly", include_endpoints = TRUE)
+  start <- as_period(test_tbl_time, "year", include_endpoints = TRUE)
 
   expect_equal(
     object = start$date[length(start$date)],
@@ -53,7 +53,7 @@ test_that("Include endpoints with side = 'start' includes last point", {
 })
 
 test_that("Include endpoints with side = 'start' includes last point", {
-  end <- as_period(test_tbl_time, "yearly",
+  end <- as_period(test_tbl_time, "year",
                      side = "end", include_endpoints = TRUE)
 
   expect_equal(
@@ -62,12 +62,12 @@ test_that("Include endpoints with side = 'start' includes last point", {
 })
 
 test_that("Error with non tbl_time object", {
-  expect_error(as_period(test_time, "yearly"),
+  expect_error(as_period(test_time, "year"),
                "Object is not of class `tbl_time`.")
 })
 
 test_that("Groups are respected", {
-  test_period <- as_period(test_tbl_time_g, "yearly")
+  test_period <- as_period(test_tbl_time_g, "year")
   expect_equal(nrow(test_period), 16L)
   expect_equal(ncol(test_period), 8L)
 })

--- a/tests/testthat/test_ceiling_index.R
+++ b/tests/testthat/test_ceiling_index.R
@@ -17,14 +17,14 @@ test_tbl_time <- test_tbl_time %>%
 # Tests
 
 test_that("Ceiling all Date/Datetime to yearly results in the same answer", {
-  test <- purrr::map_dfc(test_tbl_time, ~ceiling_index(.x, "yearly") %>% to_posixct_numeric)
+  test <- purrr::map_dfc(test_tbl_time, ~ceiling_index(.x, "year") %>% to_posixct_numeric)
   expect_equal(test$date, test$date_posix)
   expect_equal(test$date, test$date_yearmon)
   expect_equal(test$date, test$date_yearqtr)
 })
 
 test_that("Ceiling works with hms", {
-  hms_test <- create_series('01'~'12', period = "hourly", class = "hms")
+  hms_test <- create_series('01'~'12', period = "hour", class = "hms")
   expect_equal(
     ceiling_index(hms_test$date, "12 hour"),
     rep(43200, 12) %>% hms::as_hms()

--- a/tests/testthat/test_collapse_index.R
+++ b/tests/testthat/test_collapse_index.R
@@ -12,13 +12,13 @@ test_time <- tibble::tibble(
 # Tests
 
 test_that("Yearly collapse returns correct dates", {
-  test <- collapse_index(test_time$date, "yearly")
+  test <- collapse_index(test_time$date, "year")
   expect_equal(unique(test),
                as.Date("2017-12-03"))
 })
 
 test_that("side = 'start' returns start of period", {
-  test <- collapse_index(test_time$date, "yearly", side = "start")
+  test <- collapse_index(test_time$date, "year", side = "start")
   expect_equal(unique(test),
                as.Date("2017-12-01"))
 })
@@ -31,16 +31,16 @@ test_that("Index vectors can be passed to the period argument", {
 })
 
 test_that("Collapsing works on yearmon", {
-  ex <- create_series(~'2017', "monthly", "yearmon")
+  ex <- create_series(~'2017', "month", "yearmon")
 
-  expect_equal(collapse_index(ex$date, "yearly"),
+  expect_equal(collapse_index(ex$date, "year"),
                zoo::as.yearmon(rep(2017.917, 12)))
 })
 
 test_that("Collapsing works on yearqtr", {
   ex <- create_series(~'2017', "quarter", "yearqtr")
 
-  expect_equal(collapse_index(ex$date, "yearly"),
+  expect_equal(collapse_index(ex$date, "year"),
                zoo::as.yearqtr(rep(2017.75, 4)))
 })
 

--- a/tests/testthat/test_floor_index.R
+++ b/tests/testthat/test_floor_index.R
@@ -17,14 +17,14 @@ test_tbl_time <- test_tbl_time %>%
 # Tests
 
 test_that("Floor all Date/Datetime to yearly results in the same answer", {
-  test <- purrr::map_dfc(test_tbl_time, ~floor_index(.x, "yearly") %>% to_posixct_numeric)
+  test <- purrr::map_dfc(test_tbl_time, ~floor_index(.x, "year") %>% to_posixct_numeric)
   expect_equal(test$date, test$date_posix)
   expect_equal(test$date, test$date_yearmon)
   expect_equal(test$date, test$date_yearqtr)
 })
 
 test_that("Floor works with hms", {
-  hms_test <- create_series('01'~'12', period = "hourly", class = "hms")
+  hms_test <- create_series('01'~'12', period = "hour", class = "hms")
   expect_equal(
     floor_index(hms_test$date, "12 hour"),
     c(rep(0, 11), 43200) %>% hms::as_hms()

--- a/vignettes/TT-02-changing-time-periods.Rmd
+++ b/vignettes/TT-02-changing-time-periods.Rmd
@@ -53,7 +53,7 @@ To see this in action, transform the daily `FB` data set to monthly data.
 as_period(FB, '1 month')
 
 # Additionally, the following are equivalent
-# as_period(FB, 'monthly')
+# as_period(FB, 'month')
 # as_period(FB, 'm')
 # as_period(FB, '1 m')
 ```
@@ -85,12 +85,12 @@ By default, the date that starts the first group is calculated as:
 2) Floor that date to the period that you specified. 
 
 In the 1 month example above, `2013-01-02` is the first date in the series, 
-and because "monthly" was chosen, the first group is defined as 
+and because "month" was chosen, the first group is defined as 
 (2013-01-01 to 2013-01-31).
 
 Occasionally this is not what you want. Consider what would happen if you 
 changed the period to "every 2 days". The first date is `2013-01-02`, but 
-because "daily" is chosen, this isn't floored to `2013-01-01` so the groups are
+because "day" is chosen, this isn't floored to `2013-01-01` so the groups are
 (2013-01-02, 2013-01-03), (2013-01-04, 2013-01-05) and so on. 
 If you wanted the first group to be (2013-01-01, 2013-01-02), you can use
 the `start_date` argument.

--- a/vignettes/TT-04-use-with-dplyr.Rmd
+++ b/vignettes/TT-04-use-with-dplyr.Rmd
@@ -27,7 +27,7 @@ library(tibbletime)
 library(dplyr)
 library(lubridate)
 
-series <- create_series('2013' ~ '2017', 'daily', class = "Date") %>%
+series <- create_series('2013' ~ '2017', 'day', class = "Date") %>%
   mutate(var = rnorm(n()))
 
 series
@@ -51,7 +51,7 @@ the period you are summarising at. The `tibbletime` way to do this is with
 
 ```{r}
 series %>%
-  collapse_by("monthly") %>%
+  collapse_by("month") %>%
   group_by(date) %>%
   summarise(mean_var = mean(var))
 ```
@@ -69,7 +69,7 @@ second_series <- create_series('2013' ~ '2015', '5 second')
 
 second_series %>%
   mutate(var = rnorm(n())) %>%
-  collapse_by("hourly") %>%
+  collapse_by("hour") %>%
   group_by(date) %>%
   summarise(mean_var = mean(var))
 ```
@@ -103,7 +103,7 @@ price_series <- bind_rows(list(apple = apple, facebook = facebook), .id = "symbo
 # Collapse to daily and transform to OHLC (Open, High, Low, Close), a 
 # common financial transformation
 price_series %>%
-  collapse_by("daily") %>%
+  collapse_by("day") %>%
   group_by(symbol, date) %>%
   summarise(
     open  = first(price),


### PR DESCRIPTION
- `2 weeks` never did anything and is now an actual error
- `"yearly"` was never officially supported as a period in lubridate and is now an error. The `*ly` forms have all been updated