### PR TITLE
Remove usage of non-standard `EST` time zone from tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tibbletime (development version)
 
+* Removed usage of the non-standard `EST` time zone from tests.
+
 # tibbletime 0.1.8
 
 * Multi-week periods are no longer allowed. These previously threw a warning

--- a/tests/testthat/test_create_series.R
+++ b/tests/testthat/test_create_series.R
@@ -50,8 +50,8 @@ test_that("Can create vector series", {
 })
 
 test_that("Can alter time zone", {
-  series <- create_series(~'2013-01-01', '1 day', as_vector = TRUE, tz = "EST")
-  check  <- as.POSIXct("2013-01-01", tz = "EST")
+  series <- create_series(~'2013-01-01', '1 day', as_vector = TRUE, tz = "America/New_York")
+  check  <- as.POSIXct("2013-01-01", tz = "America/New_York")
 
   expect_equal(series, check)
 })


### PR DESCRIPTION
```
Dear maintainer,

Please see the problems shown on
<https://cran.r-project.org/web/checks/check_results_tibbletime.html>.

The errors on the Debian check systems are from a recent system upgrade
to tzdata 2024b which did

   Names present only for compatibility with UNIX System V
   (last released in the 1990s) have been moved to 'backward'.

which includes CET, CST6CDT, EET, EST*, HST, MET, MST*, PST8PDT, and
WET.

Debian ships the names in 'backward' in a separate package tzdata-legacy
which is not installed "by default".

The comments in the tzdata 'backward' file say

# Although this file is optional and tzdb will work if you omit it by
# building with 'make BACKWARD=', in practice downstream users
# typically use this file for backward compatibility.

so clearly one cannot unconditionally assume that the backward
compatibility names will work.

Can you please change your code (typically tests) so that they do not
fail when the backward compatibility names are not available?

Please correct before 2024-12-09 to safely retain your package on CRAN.

Best wishes,
The CRAN Team
```